### PR TITLE
Update URL of .NET 4.6.2 devpack download

### DIFF
--- a/manifests/dotnet461.pp
+++ b/manifests/dotnet461.pp
@@ -5,7 +5,7 @@ class windows_sdks::dotnet461($tempfolder = 'C:/temp') {
   ensure_resource('file', $tempfolder, { ensure => directory })
 
   archive { "${tempfolder}/NDP461-DevPack-KB3105179-ENU.exe":
-    source  => 'https://download.microsoft.com/download/F/1/D/F1DEB8DB-D277-4EF9-9F48-3A65D4D8F965/NDP461-DevPack-KB3105179-ENU.exe',
+    source  => 'https://download.visualstudio.microsoft.com/download/pr/33a48e6c-c0d1-4321-946b-042b92bad691/a9a88bd451286ab9ea015ecc2208d725/ndp461-devpack-kb3105179-enu.exe',
     require => File[$tempfolder],
   }
   ->

--- a/manifests/dotnet462.pp
+++ b/manifests/dotnet462.pp
@@ -1,6 +1,6 @@
 # Install the .NET Framework 4.6.2 SDK
 class windows_sdks::dotnet462(
-  $source = 'https://download.microsoft.com/download/E/F/D/EFD52638-B804-4865-BB57-47F4B9C80269/NDP462-DevPack-KB3151934-ENU.exe',
+  $source = 'https://download.visualstudio.microsoft.com/download/pr/ea744c52-1db4-4173-943d-a5d18e7e0d97/105c0e17be525bb0cebc7795d7aa1c32/ndp462-devpack-kb3151934-enu.exe',
   $temp_folder = 'C:/Windows/Temp'
   ) {
 

--- a/manifests/dotnet47.pp
+++ b/manifests/dotnet47.pp
@@ -1,6 +1,6 @@
 # Install the .NET Framework 4.7 DevPack
 class windows_sdks::dotnet47(
-  $source = 'https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe',
+  $source = 'https://download.visualstudio.microsoft.com/download/pr/fe069d49-7999-4ac8-bf8d-625282915070/d52a6891b5014014e1f12df252fab620/ndp47-devpack-kb3186612-enu.exe',
   $temp_folder = 'C:/Windows/Temp'
   ) {
 

--- a/manifests/dotnet471.pp
+++ b/manifests/dotnet471.pp
@@ -1,6 +1,6 @@
 # Install the .NET Framework 4.7 DevPack
 class windows_sdks::dotnet471(
-  $source = 'https://download.microsoft.com/download/9/0/1/901B684B-659E-4CBD-BEC8-B3F06967C2E7/NDP471-DevPack-ENU.exe',
+  $source = 'https://download.visualstudio.microsoft.com/download/pr/e5eb8d37-5bbd-4fb7-a71d-b749e010ef9f/601437d729667ecd29020a829fbc4881/ndp471-devpack-enu.exe',
   $temp_folder = 'C:/Windows/Temp'
   ) {
 


### PR DESCRIPTION
Microsoft have moved the location for this download. This PR updates the URL to the new place. 